### PR TITLE
Proof of concept

### DIFF
--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ImproperlyConfigured
 import re
 import shortuuid
 from django_drf_filepond.models import TemporaryUpload, StoredUpload
-from django_drf_filepond.storage_utils import _get_storage_backend
+from django_drf_filepond.s3_move_uploader import S3MoveStorage
 from django_drf_filepond.exceptions import ConfigurationError
 from django_drf_filepond.utils import is_image_for_thumbnail
 from sorl.thumbnail import get_thumbnail
@@ -47,7 +47,7 @@ def _init_storage_backend():
     storage_module_name = getattr(local_settings, 'STORAGES_BACKEND', None)
     LOG.debug('Initialising storage backend with storage module name [%s]'
               % storage_module_name)
-    storage_backend = _get_storage_backend(storage_module_name)
+    storage_backend = S3MoveStorage()
     storage_backend_initialised = True
 
 

--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -317,7 +317,7 @@ def get_stored_upload_file_data(stored_upload, thumbnail_type):
         if not thumbnailed_solr.exists():
             LOG.error(f'Failed to produce a thumbnail [{thumbnail_type}] with config [{thumbnail_config}].')
             # returning empty file so on UI it will appear with download button
-            return (filename, bytearray())
+            return (filename, stored_upload.file.read())
         return (filename, thumbnailed_solr.read())
     return (filename, stored_upload.file.read())
 

--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -18,6 +18,7 @@ import shortuuid
 from django_drf_filepond.models import TemporaryUpload, StoredUpload
 from django_drf_filepond.storage_utils import _get_storage_backend
 from django_drf_filepond.exceptions import ConfigurationError
+from django_drf_filepond.utils import is_image_for_thumbnail
 from sorl.thumbnail import get_thumbnail
 
 # TODO: Need to refactor this into a class and put the initialisation of
@@ -306,7 +307,7 @@ def get_stored_upload_file_data(stored_upload, thumbnail_type):
         # We now know that the file exists locally and is not a directory
 
     filename = os.path.basename(stored_upload.file.name)
-    if is_image(filename) and thumbnail_type and local_settings.THUMBNAIL_SIZES:
+    if is_image_for_thumbnail(filename) and thumbnail_type and local_settings.THUMBNAIL_SIZES:
         thumbnail_config = local_settings.THUMBNAIL_SIZES.get(thumbnail_type, None)
         if not thumbnail_config:
             LOG.error(f'Unknown thumbnail size type [{thumbnail_type}] - falling back to default. ' +

--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -306,8 +306,8 @@ def get_stored_upload_file_data(stored_upload, thumbnail_type):
         # We now know that the file exists locally and is not a directory
 
     filename = os.path.basename(stored_upload.file.name)
-    if thumbnail_type and local_settings.THUMBNAIL_SIZES:
-        thumbnail_config =  local_settings.THUMBNAIL_SIZES.get(thumbnail_type, None)
+    if is_image(filename) and thumbnail_type and local_settings.THUMBNAIL_SIZES:
+        thumbnail_config = local_settings.THUMBNAIL_SIZES.get(thumbnail_type, None)
         if not thumbnail_config:
             LOG.error(f'Unknown thumbnail size type [{thumbnail_type}] - falling back to default. ' +
                 'Set thumbnail config via DJANGO_DRF_FILEPOND_THUMBNAIL_SIZES setting key.')
@@ -316,7 +316,7 @@ def get_stored_upload_file_data(stored_upload, thumbnail_type):
         if not thumbnailed_solr.exists():
             LOG.error(f'Failed to produce a thumbnail [{thumbnail_type}] with config [{thumbnail_config}].')
             # returning empty file so on UI it will appear with download button
-            return (filename, bytearray())  
+            return (filename, bytearray())
         return (filename, thumbnailed_solr.read())
     return (filename, stored_upload.file.read())
 

--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -18,6 +18,7 @@ import shortuuid
 from django_drf_filepond.models import TemporaryUpload, StoredUpload
 from django_drf_filepond.storage_utils import _get_storage_backend
 from django_drf_filepond.exceptions import ConfigurationError
+from sorl.thumbnail import get_thumbnail
 
 # TODO: Need to refactor this into a class and put the initialisation of
 # the storage backend into the init.
@@ -160,7 +161,6 @@ def _store_upload_local(destination_file_path, destination_file_name,
                       file=destination_file_path,
                       uploaded=temp_upload.uploaded,
                       uploaded_by=temp_upload.uploaded_by)
-
     try:
         if not os.path.exists(target_dir):
             os.makedirs(target_dir)
@@ -247,7 +247,7 @@ def get_stored_upload(upload_id):
     return su
 
 
-def get_stored_upload_file_data(stored_upload):
+def get_stored_upload_file_data(stored_upload, thumbnail_type):
     """
     Given a StoredUpload object, this function gets and returns the data of
     the file associated with the StoredUpload instance.
@@ -295,7 +295,6 @@ def get_stored_upload_file_data(stored_upload):
             raise FileNotFoundError(
                 'File [%s] for upload_id [%s] not found on remote file '
                 'store.' % (file_path, stored_upload.upload_id))
-        file_data = stored_upload.file.read()
     else:
         if ((not os.path.exists(file_path)) or
                 (not os.path.isfile(file_path))):
@@ -305,10 +304,21 @@ def get_stored_upload_file_data(stored_upload):
                                     % file_path)
 
         # We now know that the file exists locally and is not a directory
-        file_data = stored_upload.file.read()
 
     filename = os.path.basename(stored_upload.file.name)
-    return (filename, file_data)
+    if thumbnail_type and local_settings.THUMBNAIL_SIZES:
+        thumbnail_config =  local_settings.THUMBNAIL_SIZES.get(thumbnail_type, None)
+        if not thumbnail_config:
+            LOG.error(f'Unknown thumbnail size type [{thumbnail_type}] - falling back to default. ' +
+                'Set thumbnail config via DJANGO_DRF_FILEPOND_THUMBNAIL_SIZES setting key.')
+            thumbnail_config = '300x300'
+        thumbnailed_solr = get_thumbnail(stored_upload.file, thumbnail_config)
+        if not thumbnailed_solr.exists():
+            LOG.error(f'Failed to produce a thumbnail [{thumbnail_type}] with config [{thumbnail_config}].')
+            # returning empty file so on UI it will appear with download button
+            return (filename, bytearray())  
+        return (filename, thumbnailed_solr.read())
+    return (filename, stored_upload.file.read())
 
 
 def delete_stored_upload(upload_id, delete_file=False):

--- a/django_drf_filepond/drf_filepond_settings.py
+++ b/django_drf_filepond/drf_filepond_settings.py
@@ -69,3 +69,5 @@ ALLOW_EXTERNAL_UPLOAD_DIR = getattr(settings,
                                     False)
 # Optional permissions settings for each endpoint.
 PERMISSION_CLASSES = getattr(settings, _app_prefix+'PERMISSION_CLASSES', {})
+
+THUMBNAIL_SIZES = getattr(settings, _app_prefix+'THUMBNAIL_SIZES', {})

--- a/django_drf_filepond/s3_move_uploader.py
+++ b/django_drf_filepond/s3_move_uploader.py
@@ -1,0 +1,17 @@
+import os
+import django_drf_filepond.drf_filepond_settings as filepond_settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+class S3MoveStorage(S3Boto3Storage):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+    
+    def save(self, name, content, *args, **kwargs):
+
+        print(f"saving {name} with {content.name}")
+
+        cleaned_name = self._clean_name(name)
+        name = self._normalize_name(cleaned_name)
+        print(self.bucket.name)
+        self.bucket.Object(name).copy_from(CopySource={'Bucket': self.bucket.name, "Key": content.name})
+        return cleaned_name

--- a/django_drf_filepond/storage_utils.py
+++ b/django_drf_filepond/storage_utils.py
@@ -1,7 +1,6 @@
 import importlib
 import logging
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -3,6 +3,7 @@ import django_drf_filepond.drf_filepond_settings as local_settings
 from django.contrib.auth.models import AnonymousUser
 import shortuuid
 import six
+import mimetypes
 
 
 # Get the user associated with the provided request. If we have an anonymous
@@ -43,3 +44,8 @@ def _process_base_dir(base_dir):
     if isinstance(base_dir, Path):
         return str(base_dir)
     return base_dir
+
+
+def is_image_for_thumbnail(file_name):
+    content_type = mimetypes.guess_type(file_name)[0]
+    return content_type and content_type.startswith('image/') and not content_type.startswith('image/svg')

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -48,4 +48,9 @@ def _process_base_dir(base_dir):
 
 def is_image_for_thumbnail(file_name):
     content_type = mimetypes.guess_type(file_name)[0]
-    return content_type and content_type.startswith('image/') and not content_type.startswith('image/svg')
+    return (
+            content_type and
+            content_type.startswith('image/') and
+            not content_type.startswith('image/svg') and
+            content_type != 'image/heic'
+    )

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -64,7 +64,7 @@ def _get_content_type(data, temporary=True):
 
 def is_image(file_name):
     content_type = mimetypes.guess_type(file_name)[0]
-    return content_type and content_type.startswith('image/') and content_type != 'image/svg'
+    return content_type and content_type.startswith('image/') and not content_type.startswith('image/svg')
 
 
 def _import_permission_classes(endpoint):

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -64,7 +64,7 @@ def _get_content_type(data, temporary=True):
 
 def is_image(file_name):
     content_type = mimetypes.guess_type(file_name)[0]
-    return content_type and content_type.startswith('image/')
+    return content_type and content_type.startswith('image/') and content_type != 'image/svg'
 
 
 def _import_permission_classes(endpoint):

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -31,7 +31,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from django_drf_filepond.uploaders import FilepondFileUploader
 from django_drf_filepond.utils import _get_file_id, _get_user,\
-    get_local_settings_base_dir
+    get_local_settings_base_dir, is_image_for_thumbnail
 from django.utils.encoding import escape_uri_path
 
 LOG = logging.getLogger(__name__)
@@ -60,11 +60,6 @@ except NameError:
 # 'data' will be the header data from the file to enable file type detection.
 def _get_content_type(data, temporary=True):
     return mimetypes.guess_type(data)[0]
-
-
-def is_image(file_name):
-    content_type = mimetypes.guess_type(file_name)[0]
-    return content_type and content_type.startswith('image/') and not content_type.startswith('image/svg')
 
 
 def _import_permission_classes(endpoint):
@@ -243,7 +238,7 @@ class LoadView(APIView):
                       % (upload_id, str(e)))
             return Response('Not found', status=status.HTTP_404_NOT_FOUND)
 
-        thumbnail_type = request.GET.get('thumbnail', None) if is_image(su.file.name) else None
+        thumbnail_type = request.GET.get('thumbnail', None) if is_image_for_thumbnail(su.file.name) else None
         # su is now the StoredUpload record for the requested file
         try:
             (filename, data_bytes) = get_stored_upload_file_data(su, thumbnail_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ requests>=2.20.1
 shortuuid==0.5.0;python_version=="2.7"
 shortuuid>=0.5.0;python_version>="3.5"
 six>=1.14.0
+sorl-thumbnail==12.8.0
 sphinx==1.8.2
 sphinx_rtd_theme==0.4.2
 sphinx-prompt==1.0.0
 wheel;python_version=="3.5"
+

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "django-storages>=1.9.1;python_version>='3.5'",
         "six>=1.14.0",
         "sorl-thumbnail==12.8.0",
+        "boto3==1.24.20",
+        "botocore==1.27.20",
     ],
     tests_require=[
         "nose",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         "requests>=2.20.1",
         "django-storages==1.9.1;python_version=='2.7'",
         "django-storages>=1.9.1;python_version>='3.5'",
-        "six>=1.14.0"
+        "six>=1.14.0",
+        "sorl-thumbnail==12.8.0",
     ],
     tests_require=[
         "nose",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ class AppSettingsTestCase(TestCase):
     def test_default_upload_config(self):
         reload_module(local_settings)
         from django_drf_filepond import models
-        upload_tmp = models.storage.location
+        upload_tmp = models.chunked_storage.location
         LOG.debug('We have a settings value of: %s' % (upload_tmp))
         self.assertEqual(upload_tmp,
                          os.path.join(local_settings.BASE_DIR,

--- a/tests/test_process_view.py
+++ b/tests/test_process_view.py
@@ -110,15 +110,15 @@ class ProcessTestCase(TestCase):
         setattr(drf_filepond_settings, 'UPLOAD_TMP', upload_tmp)
 
     def test_process_invalid_storage_location(self):
-        old_storage = views.storage
-        views.storage = FileSystemStorage(location='/django_test')
+        old_storage = views.chunked_storage
+        views.chunked_storage = FileSystemStorage(location='/django_test')
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
                       data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
-        views.storage = old_storage
+        views.chunked_storage = old_storage
         self.assertEqual(response.status_code, 500, 'Expecting 500 error due'
                          ' to invalid storage location.')
         self.assertEqual(
@@ -185,15 +185,15 @@ class ProcessTestCase(TestCase):
                                                 'in request data.'))
 
     def test_store_upload_with_storage_outside_BASE_DIR_without_enable(self):
-        old_storage = views.storage
-        views.storage = FileSystemStorage(location='/tmp/uploads')
+        old_storage = views.chunked_storage
+        views.chunked_storage = FileSystemStorage(location='/tmp/uploads')
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
                       data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
-        views.storage = old_storage
+        views.chunked_storage = old_storage
         self.assertEqual(response.status_code, 500, 'Expecting 500 error due'
                          ' to invalid storage location.')
         self.assertEqual(
@@ -203,12 +203,12 @@ class ProcessTestCase(TestCase):
              'incorrectly.'))
 
     def test_store_upload_with_storage_outside_BASE_DIR_with_enable(self):
-        old_storage = views.storage
+        old_storage = views.chunked_storage
         old_UPLOAD_TMP = drf_filepond_settings.UPLOAD_TMP
 
         drf_filepond_settings.ALLOW_EXTERNAL_UPLOAD_DIR = True
 
-        views.storage = FileSystemStorage(location='/tmp/uploads')
+        views.chunked_storage = FileSystemStorage(location='/tmp/uploads')
         drf_filepond_settings.UPLOAD_TMP = '/tmp/uploads'
 
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
@@ -217,7 +217,7 @@ class ProcessTestCase(TestCase):
                       data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
-        views.storage = old_storage
+        views.chunked_storage = old_storage
         drf_filepond_settings.UPLOAD_TMP = old_UPLOAD_TMP
         drf_filepond_settings.ALLOW_EXTERNAL_UPLOAD_DIR = False
         self.assertEqual(response.status_code, 200, 'Expecting upload to be '

--- a/tests/test_revert_view.py
+++ b/tests/test_revert_view.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from django_drf_filepond.utils import _get_file_id
-from django_drf_filepond.models import TemporaryUpload, storage
+from django_drf_filepond.models import TemporaryUpload, chunked_storage
 import django_drf_filepond.drf_filepond_settings as local_settings
 from django_drf_filepond.views import RevertView
 
@@ -26,7 +26,7 @@ class RevertTestCase(TestCase):
         # Set up a database containing a mock file record
         data = BytesIO()
         data.write(os.urandom(16384))
-        self.base_upload_dir_at_startup = os.path.exists(storage.location)
+        self.base_upload_dir_at_startup = os.path.exists(chunked_storage.location)
         self.file_id = _get_file_id()
         self.upload_id = _get_file_id()
         test_file = SimpleUploadedFile(self.file_id, data.read())
@@ -40,7 +40,7 @@ class RevertTestCase(TestCase):
     def tearDown(self):
         self.tu.delete()
         # Check that temp files in the storage directory have been removed
-        upload_dir_to_check = os.path.join(storage.location, self.upload_id)
+        upload_dir_to_check = os.path.join(chunked_storage.location, self.upload_id)
         upload_file_to_check = os.path.join(upload_dir_to_check, self.file_id)
         if (os.path.exists(upload_file_to_check) and
                 os.path.isfile(upload_file_to_check)):
@@ -51,10 +51,10 @@ class RevertTestCase(TestCase):
 
         # If the base upload dir didn't exist at startup, we remove it now
         if not self.base_upload_dir_at_startup:
-            if len(os.listdir(storage.location)) == 0:
+            if len(os.listdir(chunked_storage.location)) == 0:
                 LOG.debug('Removing base upload directory since it was '
                           'not present at start of test run.')
-                os.rmdir(storage.location)
+                os.rmdir(chunked_storage.location)
             else:
                 LOG.warning('Base upload directory wasn\'t present at '
                             'start of tests but can\'t delete it because '

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -32,8 +32,8 @@ class SignalsTestCase(TestCase):
         # Mock a TemporaryUpload instance object
         tu = Mock(spec=TemporaryUpload)
         upload_file = Mock(spec=SimpleUploadedFile)
-        models.storage = Mock(spec=FileSystemStorage)
-        models.storage.location = tmp_dir_split[0]
+        models.chunked_storage = Mock(spec=FileSystemStorage)
+        models.chunked_storage.location = tmp_dir_split[0]
 
         upload_file.path = path
         tu.upload_id = tmp_dir_split[1]

--- a/tests/test_uploaders_chunked.py
+++ b/tests/test_uploaders_chunked.py
@@ -9,7 +9,7 @@ from django_drf_filepond.renderers import PlainTextRenderer
 from django_drf_filepond.utils import _get_file_id
 from rest_framework.request import Request
 
-from django_drf_filepond.uploaders import FilepondChunkedFileUploader, storage
+from django_drf_filepond.uploaders import FilepondChunkedFileUploader, chunked_storage
 import django_drf_filepond
 from six import ensure_text, ensure_binary
 
@@ -532,7 +532,7 @@ class UploadersFileChunkedTestCase(TestCase):
         tuc = self._setup_tuc(True)
         tuc.last_chunk = 3
         tuc.save()
-        chunk_base = os.path.join(storage.base_location, tuc.upload_dir,
+        chunk_base = os.path.join(chunked_storage.base_location, tuc.upload_dir,
                                   '%s_' % (tuc.file_id))
 
         def mock_path_exists_se(chunk_file):
@@ -564,7 +564,7 @@ class UploadersFileChunkedTestCase(TestCase):
 
         tuc.save = MagicMock()
 
-        chunk_base = os.path.join(storage.base_location, tuc.upload_dir,
+        chunk_base = os.path.join(chunked_storage.base_location, tuc.upload_dir,
                                   tuc.file_id)
 
         def mock_path_exists_se(chunk_file):
@@ -599,7 +599,7 @@ class UploadersFileChunkedTestCase(TestCase):
         tuc.save = MagicMock()
         tuc.delete = MagicMock()
 
-        chunk_base = os.path.join(storage.base_location, tuc.upload_dir,
+        chunk_base = os.path.join(chunked_storage.base_location, tuc.upload_dir,
                                   tuc.file_id)
 
         def mock_path_exists_se(chunk_file):
@@ -637,7 +637,7 @@ class UploadersFileChunkedTestCase(TestCase):
         tuc.save = MagicMock()
         tuc.delete = MagicMock()
 
-        chunk_base = os.path.join(storage.base_location, tuc.upload_dir,
+        chunk_base = os.path.join(chunked_storage.base_location, tuc.upload_dir,
                                   tuc.file_id)
 
         def mock_path_exists_se(chunk_file):


### PR DESCRIPTION
1. Replace TemporaryUpload storage with vanila DrfFilePondStoredStorage - now we upload to s3 from UI
2. Split storage into chunked_storage for FilepondChunkedFileUploader and temp_storage for whole file. FilepondChunkedFileUploader still uses local storage and that looks ok.
3.  Change clean-up logic, so we use temporary_storage instead of os module API - now local storage and S3 storage for temp_storage can clean up temp files
4. Create S3MoveStorage based on S3Boto3Storage - only difference is that on `save` it moves file. Now this has the biggest weakness - we get `content` to the `storage.save`.
5. Current implementation assumes that a) it's an s3 file passed to a `save` (it's ok) b) iat assumes that s3 is stored in the same bucket - this is an implicit contract that is fragile. We can pass `temporary_storage` to our S3Boto3Storage init, so we can take bucket name from it.

14mb files took 4-5 sec for upload. 
When clicked `save` with 10 14mb images, it took 5s to save the page. 10x speed improvement, yet - not perfect. 

One alternative - try option with s3 retention period based in tags:
  1. when temp object created put a tag on it.
  2. configure clean up policy in s3 to clean up files with tags
  3. on `storage.save` only remove tag.
This might work, but we will need to take `destination_path` for StoredUpload from storage.save - we will effectively substitute requested path with temp s3 file path. Will require testing. 
This should bring latency to 100-200ms comparing to 500ms now.
